### PR TITLE
Defer UBI/options fetch until DataSourceSelector resolves

### DIFF
--- a/public/components/judgment/__tests__/judgment_create.test.tsx
+++ b/public/components/judgment/__tests__/judgment_create.test.tsx
@@ -50,6 +50,23 @@ jest.mock('../hooks/use_judgment_form', () => ({
   }),
 }));
 
+// Test double for the OSD DataSourceSelector. The button lets the test drive
+// the `setSelectedDataSource` callback synchronously to simulate the real
+// selector resolving its default after mount.
+jest.mock('../../common/datasource_selector', () => ({
+  DataSourceSelector: ({ setSelectedDataSource }: any) => (
+    <div data-test-subj="mock-datasource-selector">
+      <button
+        type="button"
+        data-test-subj="ds-pick-foo"
+        onClick={() => setSelectedDataSource('foo-ds')}
+      >
+        pick-foo
+      </button>
+    </div>
+  ),
+}));
+
 describe('JudgmentCreate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -113,18 +130,99 @@ describe('JudgmentCreate', () => {
 
   it('should render with data source enabled', () => {
     render(
-      <JudgmentCreate 
-        http={mockHttp} 
-        notifications={mockNotifications} 
+      <JudgmentCreate
+        http={mockHttp}
+        notifications={mockNotifications}
         history={mockHistory}
         dataSourceEnabled={true}
-        dataSourceManagement={{ ui: { DataSourceSelector: () => <div>DataSourceSelector</div> } } as any}
+        dataSourceManagement={{ ui: { DataSourceSelector: () => null } } as any}
         savedObjects={{ client: {} } as any}
         navigation={{} as any}
         setActionMenu={jest.fn()}
       />
     );
 
-    expect(screen.getByText('DataSourceSelector')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-datasource-selector')).toBeInTheDocument();
+  });
+
+  describe('multi-data-source initialization gating', () => {
+    // Capture every (http, notifications, dataSourceId, dataSourceEnabled,
+    // dataSourceInitialized) tuple the view passes into useJudgmentForm so we
+    // can assert on the gating flag directly.
+    const installCapturingHook = (): any[] => {
+      const captured: any[] = [];
+      const useJudgmentFormMock = jest.requireMock('../hooks/use_judgment_form');
+      useJudgmentFormMock.useJudgmentForm = jest.fn((...args: any[]) => {
+        captured.push(args);
+        return {
+          formData: { name: '', type: 'LLM_JUDGMENT', ignoreFailure: false, contextFields: [] },
+          updateFormData: jest.fn(),
+          selectedQuerySet: [],
+          setSelectedQuerySet: jest.fn(),
+          selectedSearchConfigs: [],
+          setSelectedSearchConfigs: jest.fn(),
+          selectedModel: [],
+          setSelectedModel: jest.fn(),
+          querySetOptions: [],
+          searchConfigOptions: [],
+          modelOptions: [],
+          isLoadingQuerySets: false,
+          isLoadingSearchConfigs: false,
+          isLoadingModels: false,
+          nameError: '',
+          newContextField: '',
+          setNewContextField: jest.fn(),
+          addContextField: jest.fn(),
+          removeContextField: jest.fn(),
+          validateAndSubmit: jest.fn(),
+        };
+      });
+      return captured;
+    };
+
+    it('passes dataSourceInitialized=true to the form hook when multi-data-source is disabled', () => {
+      const captured = installCapturingHook();
+
+      render(
+        <JudgmentCreate
+          http={mockHttp}
+          notifications={mockNotifications}
+          history={mockHistory}
+        />
+      );
+
+      const lastCall = captured[captured.length - 1];
+      // Signature: (http, notifications, dataSourceId, dataSourceEnabled, dataSourceInitialized)
+      expect(lastCall[3]).toBe(false);
+      expect(lastCall[4]).toBe(true);
+    });
+
+    it('starts with dataSourceInitialized=false when multi-data-source is enabled and flips to true after the selector reports', () => {
+      const captured = installCapturingHook();
+
+      render(
+        <JudgmentCreate
+          http={mockHttp}
+          notifications={mockNotifications}
+          history={mockHistory}
+          dataSourceEnabled={true}
+          dataSourceManagement={{ ui: { DataSourceSelector: () => null } } as any}
+          savedObjects={{ client: {} } as any}
+        />
+      );
+
+      const firstCall = captured[0];
+      expect(firstCall[3]).toBe(true);
+      expect(firstCall[4]).toBe(false);
+
+      // Selector reports a data source — gate opens, hook re-runs with both
+      // the new dataSourceId and dataSourceInitialized=true.
+      fireEvent.click(screen.getByTestId('ds-pick-foo'));
+
+      const lastCall = captured[captured.length - 1];
+      expect(lastCall[2]).toBe('foo-ds');
+      expect(lastCall[3]).toBe(true);
+      expect(lastCall[4]).toBe(true);
+    });
   });
 });

--- a/public/components/judgment/__tests__/use_judgment_form.test.ts
+++ b/public/components/judgment/__tests__/use_judgment_form.test.ts
@@ -390,5 +390,49 @@ describe('useJudgmentForm', () => {
     expect(result.current.parsedJudgments).toEqual([]);
     expect(result.current.importedRatings).toEqual([]);
   });
+
+  describe('dataSourceInitialized gating', () => {
+    it('skips the initial fetch when dataSourceInitialized is false', async () => {
+      const { rerender } = renderHook(
+        ({ initialized }: { initialized: boolean }) =>
+          useJudgmentForm(mockHttp, mockNotifications, undefined, true, initialized),
+        { initialProps: { initialized: false } }
+      );
+
+      // Allow effects to flush. Nothing should have been fetched yet.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchUbiIndexes).not.toHaveBeenCalled();
+      expect(mockService.fetchQuerySets).not.toHaveBeenCalled();
+      expect(mockService.fetchSearchConfigs).not.toHaveBeenCalled();
+      expect(mockService.fetchModels).not.toHaveBeenCalled();
+
+      // Flip the gate. The hook must now fetch.
+      rerender({ initialized: true });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchUbiIndexes).toHaveBeenCalled();
+      expect(mockService.fetchQuerySets).toHaveBeenCalled();
+      expect(mockService.fetchSearchConfigs).toHaveBeenCalled();
+      expect(mockService.fetchModels).toHaveBeenCalled();
+    });
+
+    it('runs the initial fetch when the gate parameter defaults to true (multi-data-source disabled)', async () => {
+      // Default value of the new optional parameter must preserve existing
+      // single-cluster behavior — no caller updates required.
+      renderHook(() => useJudgmentForm(mockHttp, mockNotifications));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchUbiIndexes).toHaveBeenCalled();
+    });
+  });
 });
 

--- a/public/components/judgment/hooks/use_judgment_form.ts
+++ b/public/components/judgment/hooks/use_judgment_form.ts
@@ -11,7 +11,13 @@ import { buildJudgmentPayload } from '../utils/form_processor';
 import { processJudgmentFile } from '../utils/judgment_file_processor';
 import moment from 'moment';
 
-export const useJudgmentForm = (http: any, notifications: any, dataSourceId?: string, dataSourceEnabled = false) => {
+export const useJudgmentForm = (
+  http: any,
+  notifications: any,
+  dataSourceId?: string,
+  dataSourceEnabled = false,
+  dataSourceInitialized = true
+) => {
   // Form data
   const [formData, setFormData] = useState<JudgmentFormData>({
     name: '',
@@ -110,8 +116,13 @@ export const useJudgmentForm = (http: any, notifications: any, dataSourceId?: st
   }, [formData.type, http, notifications.toasts, dataSourceId, dataSourceEnabled]);
 
   useEffect(() => {
+    // When multi-data-source is enabled, defer the initial fetch until the
+    // OSD DataSourceSelector has reported its resolved default. Otherwise we
+    // would query the local cluster with an empty dataSourceId and surface
+    // stale options from the wrong cluster.
+    if (!dataSourceInitialized) return;
     fetchData();
-  }, [fetchData]);
+  }, [fetchData, dataSourceInitialized]);
 
   const updateFormData = useCallback((updates: Partial<JudgmentFormData>) => {
     setFormData((prev) => ({ ...prev, ...updates }));

--- a/public/components/judgment/views/judgment_create.tsx
+++ b/public/components/judgment/views/judgment_create.tsx
@@ -28,6 +28,15 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
   dataSourceManagement,
 }) => {
   const [selectedDataSource, setSelectedDataSource] = useState<string>('');
+  // When multi-data-source is enabled, the OSD DataSourceSelector resolves its
+  // default asynchronously. Defer the initial fetch until it reports.
+  const [dataSourceInitialized, setDataSourceInitialized] = useState(!dataSourceEnabled);
+
+  const handleDataSourceChange = useCallback((id: string) => {
+    setSelectedDataSource(id);
+    setDataSourceInitialized(true);
+  }, []);
+
   const {
     formData,
     updateFormData,
@@ -55,7 +64,13 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
     dateRangeError,
     parsedJudgments,
     parseSummary,
-  } = useJudgmentForm(http, notifications, selectedDataSource || undefined, dataSourceEnabled);
+  } = useJudgmentForm(
+    http,
+    notifications,
+    selectedDataSource || undefined,
+    dataSourceEnabled,
+    dataSourceInitialized
+  );
 
   const handleSubmit = useCallback(() => {
     validateAndSubmit(() => {
@@ -102,7 +117,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
               dataSourceManagement={dataSourceManagement}
               savedObjects={savedObjects}
               selectedDataSource={selectedDataSource}
-              setSelectedDataSource={setSelectedDataSource}
+              setSelectedDataSource={handleDataSourceChange}
             />
           )}
           <JudgmentForm

--- a/public/components/query_set/__tests__/query_set_create.test.tsx
+++ b/public/components/query_set/__tests__/query_set_create.test.tsx
@@ -28,6 +28,29 @@ jest.mock('../components/query_preview', () => ({
     <div data-test-subj="query-preview">{parsedQueries.length} queries</div>
   ),
 }));
+// Test double for the OSD DataSourceSelector. The component lets the test
+// drive `setSelectedDataSource` synchronously to simulate the selector's
+// asynchronous resolution.
+jest.mock('../../common/datasource_selector', () => ({
+  DataSourceSelector: ({ setSelectedDataSource }: any) => (
+    <div data-test-subj="mock-datasource-selector">
+      <button
+        type="button"
+        data-test-subj="ds-pick-foo"
+        onClick={() => setSelectedDataSource('foo-ds')}
+      >
+        pick-foo
+      </button>
+      <button
+        type="button"
+        data-test-subj="ds-pick-empty"
+        onClick={() => setSelectedDataSource('')}
+      >
+        pick-empty
+      </button>
+    </div>
+  ),
+}));
 
 const mockFormState = {
   name: 'Test Query Set',
@@ -68,6 +91,7 @@ const mockFormState = {
 
 const mockQuerySetServiceInstance = {
   createQuerySet: jest.fn(),
+  fetchUbiIndexes: jest.fn(),
 };
 
 describe('QuerySetCreate', () => {
@@ -88,6 +112,7 @@ describe('QuerySetCreate', () => {
 
     // Reset mocks
     jest.clearAllMocks();
+    mockQuerySetServiceInstance.fetchUbiIndexes.mockResolvedValue([]);
 
     // Mock the hook return value
     (require('../hooks/use_query_set_form').useQuerySetForm as jest.Mock).mockReturnValue(
@@ -192,5 +217,67 @@ describe('QuerySetCreate', () => {
 
     expect(screen.getByTestId('query-preview')).toBeInTheDocument();
     expect(screen.getByText('2 queries')).toBeInTheDocument();
+  });
+
+  describe('UBI index fetch gating with multi-data-source', () => {
+    const renderWithDataSource = (dataSourceEnabled: boolean) =>
+      render(
+        <Router history={history}>
+          <QuerySetCreate
+            http={mockHttp}
+            notifications={mockNotifications}
+            history={history}
+            location={history.location}
+            match={{ params: {}, isExact: true, path: '', url: '' }}
+            dataSourceEnabled={dataSourceEnabled}
+            dataSourceManagement={
+              { ui: { DataSourceSelector: () => null } } as any
+            }
+            savedObjects={{ client: {} } as any}
+          />
+        </Router>
+      );
+
+    it('fetches UBI indexes immediately when multi-data-source is disabled', async () => {
+      renderWithDataSource(false);
+
+      await waitFor(() => {
+        expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledTimes(1);
+      });
+      // Single-cluster: no dataSourceId argument.
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledWith(undefined);
+    });
+
+    it('defers UBI index fetch until selector reports when multi-data-source is enabled', async () => {
+      renderWithDataSource(true);
+
+      // Allow effects to flush; the gate must keep the fetch from firing.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).not.toHaveBeenCalled();
+
+      // Selector reports a chosen data source — fetch must run with that id.
+      fireEvent.click(screen.getByTestId('ds-pick-foo'));
+
+      await waitFor(() => {
+        expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledTimes(1);
+      });
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledWith('foo-ds');
+    });
+
+    it('fetches against the local cluster when the selector resolves to local (empty id)', async () => {
+      renderWithDataSource(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).not.toHaveBeenCalled();
+
+      // Selector picks the local cluster — empty id is a legitimate selection,
+      // not a "not initialized yet" state. The fetch must still fire.
+      fireEvent.click(screen.getByTestId('ds-pick-empty'));
+
+      await waitFor(() => {
+        expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledTimes(1);
+      });
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledWith(undefined);
+    });
   });
 });

--- a/public/components/query_set/views/query_set_create.tsx
+++ b/public/components/query_set/views/query_set_create.tsx
@@ -41,11 +41,22 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
   const querySetService = useMemo(() => new QuerySetService(http), [http]);
   const filePickerId = useMemo(() => `filePicker-${Math.random().toString(36).substr(2, 9)}`, []);
   const [selectedDataSource, setSelectedDataSource] = useState<string>('');
-  
+  // When multi-data-source is enabled, the OSD DataSourceSelector resolves its
+  // default asynchronously. We must wait for its first onSelectedDataSource
+  // callback before fetching, otherwise we'd query the local cluster with an
+  // empty dataSourceId and show stale UBI indexes from the wrong cluster.
+  const [dataSourceInitialized, setDataSourceInitialized] = useState(!dataSourceEnabled);
+
+  const handleDataSourceChange = useCallback((id: string) => {
+    setSelectedDataSource(id);
+    setDataSourceInitialized(true);
+  }, []);
+
   const [indexOptions, setIndexOptions] = useState<Array<{ label: string; value: string }>>([]);
   const [isLoadingIndexes, setIsLoadingIndexes] = useState(false);
 
   useEffect(() => {
+    if (!dataSourceInitialized) return;
     const fetchIndexes = async () => {
       setIsLoadingIndexes(true);
       try {
@@ -62,7 +73,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
     fetchIndexes();
     formState.setUbiQueriesIndex('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [querySetService, selectedDataSource]);
+  }, [querySetService, selectedDataSource, dataSourceInitialized]);
 
   const createQuerySet = useCallback(async () => {
     if (!formState.isFormValid()) {
@@ -141,7 +152,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
               dataSourceManagement={dataSourceManagement}
               savedObjects={savedObjects}
               selectedDataSource={selectedDataSource}
-              setSelectedDataSource={setSelectedDataSource}
+              setSelectedDataSource={handleDataSourceChange}
             />
           )}
           <QuerySetForm 


### PR DESCRIPTION


### Description

When `dataSourceEnabled` is true, the OSD `DataSourceSelector` resolves its default asynchronously. The query set and judgment create views were firing their option fetches on mount with an empty `dataSourceId`, which queried the local cluster instead of the user's selected remote cluster and surfaced stale options for the wrong cluster.

Gate the initial fetch on a `dataSourceInitialized` flag that flips to `true` only after `DataSourceSelector` invokes its callback (or immediately if `dataSourceEnabled` is false, preserving single-cluster behavior). An empty selector callback is treated as a legitimate local-cluster pick, not as "not initialized yet".

- query_set/views/query_set_create.tsx: gate `useEffect`, wrap the selector callback to flip the flag.
- judgment/hooks/use_judgment_form.ts: accept optional `dataSourceInitialized = true` and gate the fetch effect; default preserves the existing listing-view caller's behavior.
- judgment/views/judgment_create.tsx: mirror the query-set fix and pass the flag into the hook.
- Add gating coverage to query_set_create, judgment_create, and use_judgment_form test suites.

### Issues Resolved



### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
